### PR TITLE
Narrow the type of Util.fd_of_unix

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -4,6 +4,6 @@ end
 
 let max_open_files = Raw.max_open_files
 
-let fd_of_unix fd = (Obj.magic fd : int)
+let fd_of_unix (fd : Unix.file_descr) = (Obj.magic fd : int)
 
 let unix_of_fd (fd : int) : Unix.file_descr = (Obj.magic fd)


### PR DESCRIPTION
Before it would make anything to an int. Now it only works on Unix.file_descr.

On OCaml 4.14.0 I also had to change `caml_uerror` into `uerror` FWIW.