### PR TITLE
Add type magic!

### DIFF
--- a/lib/poll.ml
+++ b/lib/poll.ml
@@ -13,9 +13,9 @@ end
 module Flags = struct
   type output = < output: unit; >
 
-  type 'a input = < .. > as 'a
+  type 'a either = < .. > as 'a
 
-  type input_only = < >
+  type input = < >
 
   type 'a t = int
 

--- a/lib/poll.ml
+++ b/lib/poll.ml
@@ -36,7 +36,7 @@ module Flags = struct
   let of_int = Fun.id
 
   let input_of_int n =
-    if mem pollerr n || mem pollhup n || mem pollnval n then
+    if mem (pollerr + pollhup + pollnval) n then
       invalid_arg "Poll.Flag.input_of_int";
     n
 end

--- a/lib/poll.ml
+++ b/lib/poll.ml
@@ -11,7 +11,13 @@ module Raw = struct
 end
 
 module Flags = struct
-  type t = int
+  type output = < output: unit; >
+
+  type 'a input = < .. > as 'a
+
+  type input_only = < >
+
+  type 'a t = int
 
   let pollin = Config.pollin
   let pollpri = Config.pollpri
@@ -28,6 +34,11 @@ module Flags = struct
 
   let to_int = Fun.id
   let of_int = Fun.id
+
+  let input_of_int n =
+    if mem pollerr n || mem pollhup n || mem pollnval n then
+      invalid_arg "Poll.Flag.input_of_int";
+    n
 end
 
 let invalid_fd = unix_of_fd (-1)
@@ -94,7 +105,7 @@ let create ?(maxfds=Util.max_open_files ()) () =
 
 let maxfds t = t.maxfds
 
-let iter_ready t nready (f : int -> Unix.file_descr -> Flags.t -> unit) =
+let iter_ready t nready (f : int -> Unix.file_descr -> Flags.output Flags.t -> unit) =
   let rec loop index nready =
     match nready with
     | 0 -> ()

--- a/lib/poll.mli
+++ b/lib/poll.mli
@@ -46,7 +46,7 @@ module Flags : sig
   val ( + ) : 'a t -> 'a t -> 'a t
   (** The union of flags, fancy way of doing {!lor}. *)
 
-  val mem : 'a t -> 'b t -> bool
+  val mem : 'a t -> 'a t -> bool
   (** [mem x y] checks if [y] belongs to [m]. The fancy way of doing {!land}. *)
 
   val to_int : 'inout t -> int

--- a/lib/poll.mli
+++ b/lib/poll.mli
@@ -15,20 +15,20 @@ module Flags : sig
 
   type output = < output: unit; >
 
-  type 'a input = < .. > as 'a
+  type 'a either = < .. > as 'a
 
-  type input_only = < >
+  type input = < >
 
   type 'inout t
   (** The actual set. *)
 
-  val pollin : 'a input t
+  val pollin : 'a either t
   (** POLLIN from poll(2). *)
 
-  val pollpri : 'a input t
+  val pollpri : 'a either t
   (** POLLPRI from poll(2). *)
 
-  val pollout : 'a input t
+  val pollout : 'a either t
   (** POLLOUT from poll(2). *)
 
   val pollerr : output t
@@ -40,7 +40,7 @@ module Flags : sig
   val pollnval : output t
   (** POLLNVAL from poll(2). Only expected as output, invalid as input. *)
 
-  val empty : 'a input t
+  val empty : 'a either t
   (** aka zero. *)
 
   val ( + ) : 'a t -> 'a t -> 'a t
@@ -55,7 +55,7 @@ module Flags : sig
   val of_int : int -> 'inout t
   (** [of_int x] imports [x] as {!t}, this is an identity function. *)
 
-  val input_of_int : int -> input_only t
+  val input_of_int : int -> input t
 end
 
 val invalid_fd : Unix.file_descr
@@ -86,7 +86,7 @@ val ppoll : t -> int -> ppoll_timeout -> int list -> int
     nanoseconds and a list of signals that are atomically masked
     during execution and restored uppon return. *)
 
-val set_index : t -> int -> Unix.file_descr -> Flags.input_only Flags.t -> unit
+val set_index : t -> int -> Unix.file_descr -> Flags.input Flags.t -> unit
 (** [set_index t index fd flag] modifies the internal buffer at
     [index] to listen to [flag] events of [fd]. This overwrites any
     previous value of [flag] and [fd] internally. {!invalid_fd} (-1)


### PR DESCRIPTION
Using phantom types we can keep track of whether a set of flags is for output or if it is valid for both input and output.

It's been a while since I've done this sort of thing so I'd like to revisit this. I think `of_int` should be named `unsafe_of_int` and the phantom type names could likely be clearer.