### PR TITLE
Add :standard to C flags

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -9,7 +9,8 @@
  (libraries unix)
  (foreign_stubs
   (language c)
-  (flags "-Wall"
+  (flags :standard
+         "-Wall"
          ; "-Wstrict-prototypes"
          ; "-Wmissing-prototypes"
          ; "-Wmissing-declarations"


### PR DESCRIPTION
I needed this to get things compiling. Otherwise the linker was unhappy:

```Error
File "lib/dune", line 5, characters 0-386:
 5 | (library
 6 |  (name iomux)
 7 |  (public_name iomux)
....
19 |          "-Wsign-compare"
20 |          "-Werror")
21 |   (names iomux_stubs)))
/usr/bin/ld: lib/iomux_stubs.o: warning: relocation against `Caml_state' in read-only section `.text'
/usr/bin/ld: lib/iomux_stubs.o: relocation R_X86_64_PC32 against undefined symbol `Caml_state' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
```