### PR TITLE
Add Poll.get_events

### DIFF
--- a/lib/iomux_stubs.c
+++ b/lib/iomux_stubs.c
@@ -131,6 +131,14 @@ caml_iomux_poll_init(value v_fds, value v_maxfds)
 
 
 value /* noalloc */
+caml_iomux_poll_get_events(value v_fds, value v_index)
+{
+	struct pollfd *pfd = pollfd_of_index(v_fds, v_index);
+
+	return (Val_int(pfd->events));
+}
+
+value /* noalloc */
 caml_iomux_poll_get_revents(value v_fds, value v_index)
 {
 	struct pollfd *pfd = pollfd_of_index(v_fds, v_index);

--- a/lib/poll.ml
+++ b/lib/poll.ml
@@ -23,6 +23,7 @@ module Raw = struct
   external ppoll : buffer -> int -> int64 -> int list -> int = "caml_iomux_ppoll"
   external set_index : buffer -> int -> int -> int -> unit = "caml_iomux_poll_set_index" [@@noalloc]
   external init : buffer -> int -> unit = "caml_iomux_poll_init"
+  external get_events : buffer -> int -> int = "caml_iomux_poll_get_events" [@@noalloc]
   external get_revents : buffer -> int -> int = "caml_iomux_poll_get_revents" [@@noalloc]
   external get_fd : buffer -> int -> int = "caml_iomux_poll_get_fd" [@@noalloc]
 end
@@ -105,6 +106,10 @@ let set_index t index fd events =
 let invalidate_index t index =
   guard_index t index;
   Raw.set_index t.buffer index (-1) 0
+
+let get_events t index =
+  guard_index t index;
+  Raw.get_events t.buffer index
 
 let get_revents t index =
   guard_index t index;

--- a/lib/poll.mli
+++ b/lib/poll.mli
@@ -124,6 +124,10 @@ val invalidate_index : t -> int -> unit
     invalidating [index]. The kernel will ignore that slot. We also
     clear flags, just for kicks. *)
 
+val get_events : t -> int -> Flags.t
+(** [get_events t index] is the event flags to be listened for by the
+    file descriptor at [index]. *)
+
 val get_revents : t -> int -> Flags.t
 (** [get_revents t index] is the returned event flags set after a call
     to {!poll} or {!ppoll}. *)

--- a/test/test.ml
+++ b/test/test.ml
@@ -53,8 +53,10 @@ module T = struct
     let nready = Poll.poll poll 1 Nowait in
     check_int "nready" nready 1;
     let fd = Poll.get_fd poll 0 in
+    let events = Poll.get_events poll 0 in
     let revents = Poll.get_revents poll 0 in
     check_bool "fd" true (r = fd);
+    check_bool "events" true (events = Poll.Flags.pollin);
     check_bool "revents" true (Poll.Flags.mem revents Poll.Flags.pollin);
     check_bool "revents-eq" true (revents = Poll.Flags.pollin);
     Unix.close w;


### PR DESCRIPTION
This adds `get_events` to complement `get_fd` and `get_revents`.

The motivation is to allow for copying an entry over another, so that iomux's array can be kept contiguous by only ever invalidating the highest-index element:
```ocaml
let swap_invalidate iomux size idx =
  let open Iomux.Poll in
    size := ((!size) - 1);
    set_index iomux idx (get_fd iomux (!size)) (get_events iomux (!size));
    invalidate_index iomux (!size)
```