### PR TITLE
clamp max open files to 2^19 to fix recent macOS POSIX divergence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ocaml-version: ["5.0.0", "4.14.1", "4.13.1", "4.12.1", "4.11.2", "4.10.2", "4.09.1", "4.08.1"]
+        ocaml-version: ["5.3.0", "4.14.2"]
         operating-system: [macos-latest, ubuntu-latest]
 
     runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-version }}
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v0.4
+
+* Clamp max open files to 2^19, as macOS sometimes returns
+  2^32-1.
+
 ## v0.3 (2023-03-10)
 
 * Round timeouts up, not down in Poll.poll (spotted by @talex5)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
-## v0.4
+## v0.4 (2025-09-17)
 
 * Clamp max open files to 2^19, as macOS sometimes returns
-  2^32-1.
+  2^32-1 (#7 @avsm).
 
 ## v0.3 (2023-03-10)
 
@@ -11,9 +11,9 @@
 
 ## v0.2 (2023-02-27)
 
-* Narrowed the type of Util.fd_of_unix (@reynir)
-* Use older school uerror instead of caml_uerror (@reynir)
-* Added c_standard to dune build flags (@reynir)
+* Narrowed the type of `Util.fd_of_unix` (@reynir)
+* Use older school uerror instead of `caml_uerror` (@reynir)
+* Added `c_standard` to dune build flags (@reynir)
 * Addded ppoll(2) discoverability and a mini compat layer (@haesbaert)
 * Improved tests (@haesbaert)
 * Re-added macos support (@haesbaert)

--- a/lib/iomux_stubs.c
+++ b/lib/iomux_stubs.c
@@ -150,8 +150,14 @@ caml_iomux_poll_get_fd(value v_fds, value v_index)
  * Util
  */
 
-value /* noalloc */
+value
 caml_iomux_poll_max_open_files(value v_unit)
 {
-	return (Val_int(sysconf(_SC_OPEN_MAX)));
+        CAMLparam1(v_unit);
+        long r = sysconf(_SC_OPEN_MAX);
+        if (r == -1) /* this allocs */
+                uerror("poll_max_open_files", Nothing);
+        else if (r > 524288)
+                r = 524288;
+	CAMLreturn (Val_int(r));
 }

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1,5 +1,5 @@
 module Raw = struct
-  external max_open_files : unit -> int = "caml_iomux_poll_max_open_files" [@@noalloc]
+  external max_open_files : unit -> int = "caml_iomux_poll_max_open_files"
 end
 
 let max_open_files = Raw.max_open_files


### PR DESCRIPTION
This prevents recent macOS from trying to allocate a very large Bigarray at Eio start.  I'm not sure why I started seeing this just now, but it might be to do with running under more sandboxed environments (claude code etc). Other projects have seen this since 2021: https://github.com/eradman/entr/commit/8f224fb4539452dde39b4e3b341962f5946460aa

/cc @talex5 who found the forum thread https://developer.apple.com/forums/thread/666765